### PR TITLE
fix: return flag state after evaluation

### DIFF
--- a/packages/sdk/src/evaluation.ts
+++ b/packages/sdk/src/evaluation.ts
@@ -29,5 +29,5 @@ export function evaluate(flag: Flag, userPercentage: number, req: EvalRequest, d
    * No rule applied
    */
 
-  return false;
+  return flag.enabled;
 }


### PR DESCRIPTION
When no percentage or rule is applied during evaluation, return the state of the flag instead of a fixed false.

## Problem

When using the `getFlag` method on the Client class, the flag is evaluated. If no percentage or rules are present on the flag, a fixed false is returned instead of the `enabled` property of the flag.

Example:

```
import { Client, type Environment } from "@upstash/edge-flags";

const client = new Client({
  redis: Redis.fromEnv(),
  environment: (process.env.VERCEL_ENV as Environment) ?? "development",
});

const flag = await client.getFlag("flag-name", {});
//      ^ Returns false if no percentage or rules are defined
```

## Solution

Return `flag.enabled` instead of `false` at the end of the evaluation.