### PR TITLE
Fix logical error in cache eviction

### DIFF
--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -20,7 +20,7 @@ export class Cache<T> {
     if (!item) {
       return null;
     }
-    if (this.ttl && item.createdAt + this.ttl > Date.now()) {
+    if (this.ttl && (item.createdAt + this.ttl) < Date.now()) {
       this.map.delete(key);
       return null;
     }


### PR DESCRIPTION
While testing the edge-flags sdk with some unit tests, I came to notice that the cache is never working.

Turned out that this was due to a logical error in the cache eviction condition.

Equality has a higher precedence, and the direction of the validation operation was in the wrong direction (i.e., we want to check if `now()` has gone past the creation date + ttl).